### PR TITLE
Add freebsd as target for precomp NIFs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,15 +27,15 @@ jobs:
       matrix:
         nif: ["2.16", "2.15"]
         job:
-          # - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
-          # - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
-          # - { target: aarch64-apple-darwin, os: macos-11 }
-          # - { target: x86_64-apple-darwin, os: macos-11 }
-          # - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
-          # - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
-          # - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true, disable-polars-json-feature: true }
-          # - { target: x86_64-pc-windows-gnu, os: windows-2019 }
-          # - { target: x86_64-pc-windows-msvc, os: windows-2019 }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
+          - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
+          - { target: aarch64-apple-darwin, os: macos-11 }
+          - { target: x86_64-apple-darwin, os: macos-11 }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
+          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true, disable-polars-json-feature: true }
+          - { target: x86_64-pc-windows-gnu, os: windows-2019 }
+          - { target: x86_64-pc-windows-msvc, os: windows-2019 }
           - { target: x86_64-unknown-freebsd, os: ubuntu-22.04, use-cross: true }
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           # - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true, disable-polars-json-feature: true }
           # - { target: x86_64-pc-windows-gnu, os: windows-2019 }
           # - { target: x86_64-pc-windows-msvc, os: windows-2019 }
-          - { target: amd64-portbld-freebsd, os: macos-11 }
+          - { target: x86_64-unknown-freebsd, os: macos-11 }
 
     steps:
       - name: Checkout source code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
           target: ${{ matrix.job.target }}
           nif-version: ${{ matrix.nif }}
           use-cross: ${{ matrix.job.use-cross }}
+          cross-version: v0.2.5
           project-dir: "native/explorer"
 
       - name: Artifact upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           # - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true, disable-polars-json-feature: true }
           # - { target: x86_64-pc-windows-gnu, os: windows-2019 }
           # - { target: x86_64-pc-windows-msvc, os: windows-2019 }
-          - { target: x86_64-unknown-freebsd, os: macos-11 }
+          - { target: x86_64-unknown-freebsd, os: ubuntu-20.04, use-cross: true }
 
     steps:
       - name: Checkout source code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,15 +27,16 @@ jobs:
       matrix:
         nif: ["2.16", "2.15"]
         job:
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
-          - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
-          - { target: aarch64-apple-darwin, os: macos-11 }
-          - { target: x86_64-apple-darwin, os: macos-11 }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
-          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true, disable-polars-json-feature: true }
-          - { target: x86_64-pc-windows-gnu, os: windows-2019 }
-          - { target: x86_64-pc-windows-msvc, os: windows-2019 }
+          # - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
+          # - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
+          # - { target: aarch64-apple-darwin, os: macos-11 }
+          # - { target: x86_64-apple-darwin, os: macos-11 }
+          # - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
+          # - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
+          # - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true, disable-polars-json-feature: true }
+          # - { target: x86_64-pc-windows-gnu, os: windows-2019 }
+          # - { target: x86_64-pc-windows-msvc, os: windows-2019 }
+          - { target: amd64-portbld-freebsd, os: macos-11 }
 
     steps:
       - name: Checkout source code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           # - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true, disable-polars-json-feature: true }
           # - { target: x86_64-pc-windows-gnu, os: windows-2019 }
           # - { target: x86_64-pc-windows-msvc, os: windows-2019 }
-          - { target: x86_64-unknown-freebsd, os: ubuntu-20.04, use-cross: true }
+          - { target: x86_64-unknown-freebsd, os: ubuntu-22.04, use-cross: true }
 
     steps:
       - name: Checkout source code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,13 @@ jobs:
       matrix:
         nif: ["2.16", "2.15"]
         job:
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
-          - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true }
+          - { target: aarch64-unknown-linux-musl, os: ubuntu-22.04, use-cross: true }
           - { target: aarch64-apple-darwin, os: macos-11 }
           - { target: x86_64-apple-darwin, os: macos-11 }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
-          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true, disable-polars-json-feature: true }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-22.04, use-cross: true }
+          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true, disable-polars-json-feature: true }
           - { target: x86_64-pc-windows-gnu, os: windows-2019 }
           - { target: x86_64-pc-windows-msvc, os: windows-2019 }
           - { target: x86_64-unknown-freebsd, os: ubuntu-22.04, use-cross: true }


### PR DESCRIPTION
Using explorer in livebook on a freebsd host fails with

```
== Compilation error in file lib/explorer/polars_backend/native.ex ==
** (RuntimeError) precompiled NIF is not available for this target: "amd64-portbld-freebsd13.1".
The available targets are:
 - aarch64-apple-darwin
 - aarch64-unknown-linux-gnu
 - aarch64-unknown-linux-musl
 - riscv64gc-unknown-linux-gnu
 - x86_64-apple-darwin
 - x86_64-pc-windows-msvc
 - x86_64-pc-windows-gnu
 - x86_64-unknown-linux-gnu
 - x86_64-unknown-linux-musl
    lib/explorer/polars_backend/native.ex:11: (module)
```

Let's try to add freebsd to that list.